### PR TITLE
DETER (Amazônia, Cerrado e Pantanal)

### DIFF
--- a/docs/01_faxina_tratamento_dados.Rmd
+++ b/docs/01_faxina_tratamento_dados.Rmd
@@ -781,32 +781,133 @@ write_rds(prodes,"../data/prodes-deforestation.rds")
 
 ```{r, eval=FALSE}
 library(tidyverse)
-library(sf)
+library(sf) # ler shapefile
 ```
 
 ```{r, eval=FALSE}
 # Exemplo com os três shapefiles que você mostrou
-amz <- st_read("../data-raw/deter/deter-amz-deter-public.shp")
+amz <- st_read("../data-raw/deter/deter-amz-deter-public.shp") # ALB (completo, desde 2016)
 
+cerrado <- st_read("../data-raw/deter/deter-cerrado-nb-deter-public.shp") # Somente desmatamento
+
+pantanal <- st_read("../data-raw/deter/deter-pantanal-deter-public.shp") # Dados de cicatriz de queimada Somente a partir de 2023
+```
+
+
+```{r, eval=FALSE}
+# EXEMPLIFICANDO COM AMAZONIA
 # Ver estrutura
-str(amz)
+# str(amz)
+# 
+# # Visualizar os primeiros registros
+# head(amz) 
+#   # ou
+#   glimpse(amz)
+# 
+# # Visualizar nomes das colunas
+# names(amz) #Coluna de interesse ("CLASSNAME")
+# 
+# # Visualizar nomes das linhas da coluna "CLASSNAME"
+# amz$CLASSNAME
+# 
+# # Quantificar observações
+# table(amz$CLASSNAME)
+# 
+#   # Verificar valores únicos de classe e estado
+#   unique(amz$CLASSNAME) # Linha de interesse ("CICATRIZ_DE_QUEIMADA")
+#   unique(amz$UF) # Somente MT
+#   
 
-# Visualizar os primeiros registros
-head(amz)
+
+# Filtrar para linha de interesse
+amz <- amz |>
+    # select(CLASSNAME, VIEW_DATE, UF, geometry, MUNICIPALI)
+    mutate(
+      bioma = "Amazônia"
+    ) |> 
+    filter(CLASSNAME == "CICATRIZ_DE_QUEIMADA",
+           UF == "MT")
+
 
 # Plot simples
 # plot(st_geometry(amz))
 
 
-ggplot(amz |> filter(CLASSNAME == "DEGRADACAO")) +
+ggplot(amz) +
   geom_sf() +  # Preenchimento por bioma, sem contorno
   # scale_fill_manual(values = c("Amazônia" = "#1b9e77", 
   #                              "Cerrado" = "#d95f02", 
   #                              "Pantanal" = "#7570b3")) +
   theme_minimal() +
-  labs(title = "Desmatamento por Bioma (DETER)") +
+  labs(title = "Queimada Amazônia Legal brasileira (DETER)") +
   theme(legend.position = "bottom")
 ```
+
+```{r, eval=FALSE}
+# str(cerrado)
+glimpse(cerrado)
+unique(cerrado$UF)
+
+cerrado <- cerrado |> 
+  mutate(
+    bioma = "Cerrado"
+  ) |> 
+  filter(CLASSNAME == "DESMATAMENTO_CR", # Só desmat
+                     UF == c("MT", "MS", "GO", "DF"))
+
+ggplot(cerrado) +
+  geom_sf() +  # Preenchimento por bioma, sem contorno
+  # scale_fill_manual(values = c("Amazônia" = "#1b9e77", 
+  #                              "Cerrado" = "#d95f02", 
+  #                              "Pantanal" = "#7570b3")) +
+  theme_minimal() +
+  labs(title = "Desmatamento Cerrado (DETER)") +
+  theme(legend.position = "bottom")
+```
+
+```{r, eval = FALSE}
+# str(pantanal)
+glimpse(pantanal)
+unique(pantanal$CLASS_NAME)
+
+pantanal <- pantanal |> 
+  mutate(CLASSNAME = CLASS_NAME,
+         bioma = "Pantanal") |> # padronizar nome da coluna
+  filter(CLASSNAME == "cicatriz de queimada")
+
+ggplot(pantanal) +
+  geom_sf() +  # Preenchimento por bioma, sem contorno
+  # scale_fill_manual(values = c("Amazônia" = "#1b9e77", 
+  #                              "Cerrado" = "#d95f02", 
+  #                              "Pantanal" = "#7570b3")) +
+  theme_minimal() +
+  labs(title = "Queimada Pantanal (DETER)") +
+  theme(legend.position = "bottom")
+```
+
+```{r}
+# Unindo shapefiles em um único
+deter_all <- bind_rows(amz, cerrado, pantanal)
+
+# Gerando plot dos biomas 
+ggplot(deter_all) +
+  geom_sf(aes(fill = bioma), color = NA) +
+  scale_fill_manual(values = c(
+    "Amazônia" = "#1b9e77",
+    "Cerrado" = "#d95f02",
+    "Pantanal" = "#7570b3"
+  )) +
+  theme_minimal() +
+  labs(title = "Áreas com Cicatriz de Queimada e Desmatamento (DETER)",
+       fill = "Bioma") +
+  theme(legend.position = "bottom")
+
+# Baixando arquivo shapefile unido
+# write_rds(deter_all, "areas-queimada-biomas")
+```
+
+
+
 
 
 


### PR DESCRIPTION
Extração e união de dados 

Ressalta-se que para:
1. Amazônia, os dados de cicatriz de queimada estão completos (desde 2016)
2. Cerrado, não há dados de queimada, apenas desmatamento por corte raso
3. Pantanal, há somente dados de cicatriz de queimada a partir de 2023